### PR TITLE
EFOU sääaseman korjaus lentoaseman sääasemaksi

### DIFF
--- a/frontend/dropzones.json
+++ b/frontend/dropzones.json
@@ -25,9 +25,9 @@
     },
     "EFOU": {
         "icaocode": "EFOU",
-        "lat": 64.93054,
-        "lon": 25.358608,
-        "fmisid": 101799
+        "lat": 64.92966,
+        "lon": 25.371011,
+        "fmisid": 101786
     },
     "EFKE": {
         "icaocode": "EFKE",


### PR DESCRIPTION
vaihdettu EFOU asema Pellonpään asemasta lentoaseman sääasemaksi. koodinaatit korjattu tornin koordinaateiksi. Pellonpään asema ei ole virallinen, lentoaseman on